### PR TITLE
Fix efects not being rounded on scene load

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ Hooks.once("init", () => {
     });
 });
 
-Hooks.once("ready", () => {
+Hooks.once("setup", () => {
     libWrapper.register<TokenPF2e, TokenPF2e["_refreshEffects"]>(
         MODULE.id,
         "foundry.canvas.placeables.Token.prototype._refreshEffects",


### PR DESCRIPTION
Some interaction with modules and scene configs seem to trigger token effects drawing to occur before the "ready" hook to override the tokens `_drawEffect` function runs. This leads to effects still being arranged in a halo, but not being rounded like they should be.

The fix is to apply this override earlier, just after document and config setup has been completed

Before:
<img width="813" height="688" alt="image" src="https://github.com/user-attachments/assets/2f51113d-dd5f-42dd-9c82-a68e21272031" />


After:
<img width="727" height="695" alt="image" src="https://github.com/user-attachments/assets/f20218fa-5d57-419f-b8d3-c0346b802217" />
